### PR TITLE
Expose left and right icons for banner customization

### DIFF
--- a/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
+++ b/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
@@ -5,12 +5,12 @@ import UIKit
 // MARK: - WUMessagesProtocol
 
 extension WUMessagesNotificationBanner: WUMessagesProtocol {
-    
-    public static func showBanner(
-        message: WUMessage,
-        backgroundColor: UIColor?,
-        onTap: OnTap?,
-        timeout: DispatchTimeInterval) {
+    public static func showBanner(message: WUMessage,
+                                  backgroundColor: UIColor?,
+                                  onTap: OnTap?,
+                                  leftIcon: UIImage?,
+                                  rightIcon: UIImage?,
+                                  timeout: DispatchTimeInterval) {
         
         // Title
         let title = message.attributedTitle
@@ -18,12 +18,24 @@ extension WUMessagesNotificationBanner: WUMessagesProtocol {
         // Subtitle
         let subtitle = message.attributedText
         
+        // Left icon
+        var leftIconView: UIImageView!
+        if let leftIcon = leftIcon {
+            leftIconView = UIImageView(image: leftIcon)
+        }
+        
+        // Right icon
+        var rightIconView: UIImageView!
+        if let rightIcon = rightIcon {
+            rightIconView = UIImageView(image: rightIcon)
+        }
+        
         // Banner
         let banner = NotificationBanner(
             attributedTitle: title,
             attributedSubtitle: subtitle,
-            leftView: nil,
-            rightView: nil,
+            leftView: leftIconView,
+            rightView: rightIconView,
             style: .info, // Can't be custom, to use background color afterwards
             colors: nil
         )

--- a/Sources/WUMessagesProtocol.swift
+++ b/Sources/WUMessagesProtocol.swift
@@ -5,11 +5,13 @@ public protocol WUMessagesProtocol {
     
     typealias OnTap = () -> Void
     
-    /// Shows a notification look alike banner, without image
+    /// Shows a notification look alike banner, including images if needed
     static func showBanner(
         message: WUMessage,
         backgroundColor: UIColor?,
         onTap: OnTap?,
+        leftIcon: UIImage?,
+        rightIcon: UIImage?,
         timeout: DispatchTimeInterval
     )
     


### PR DESCRIPTION
This PR exposes both `leftIcon` and `rightIcon` as parameters when showing a banner, to allow for further customization (already enabled by underlying library).