### PR TITLE
Expose icon tint color

### DIFF
--- a/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
+++ b/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
@@ -8,8 +8,10 @@ extension WUMessagesNotificationBanner: WUMessagesProtocol {
     public static func showBanner(message: WUMessage,
                                   backgroundColor: UIColor?,
                                   onTap: OnTap?,
-                                  leftIcon: UIImage?,
-                                  rightIcon: UIImage?,
+                                  leftIcon: UIImage? = nil,
+                                  leftIconColor: UIColor? = nil,
+                                  rightIcon: UIImage? = nil,
+                                  rightIconColor: UIColor? = nil,
                                   timeout: DispatchTimeInterval) {
         
         // Title
@@ -21,13 +23,21 @@ extension WUMessagesNotificationBanner: WUMessagesProtocol {
         // Left icon
         var leftIconView: UIImageView!
         if let leftIcon = leftIcon {
-            leftIconView = UIImageView(image: leftIcon)
+            leftIconView = UIImageView(image: leftIcon.withRenderingMode(.alwaysTemplate))
+            
+            if let leftIconColor = leftIconColor {
+                leftIconView.tintColor = leftIconColor
+            }
         }
         
         // Right icon
         var rightIconView: UIImageView!
         if let rightIcon = rightIcon {
-            rightIconView = UIImageView(image: rightIcon)
+            rightIconView = UIImageView(image: rightIcon.withRenderingMode(.alwaysTemplate))
+            
+            if let rightIconColor = rightIconColor {
+                rightIconView.tintColor = rightIconColor
+            }
         }
         
         // Banner

--- a/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
+++ b/Sources/WUMessages+NotificationBanner/WUMessagesNotificationBanner+WUMessagesProtocol.swift
@@ -23,20 +23,22 @@ extension WUMessagesNotificationBanner: WUMessagesProtocol {
         // Left icon
         var leftIconView: UIImageView!
         if let leftIcon = leftIcon {
-            leftIconView = UIImageView(image: leftIcon.withRenderingMode(.alwaysTemplate))
-            
             if let leftIconColor = leftIconColor {
+                leftIconView = UIImageView(image: leftIcon.withRenderingMode(.alwaysTemplate))
                 leftIconView.tintColor = leftIconColor
+            } else {
+                leftIconView = UIImageView(image: leftIcon)
             }
         }
         
         // Right icon
         var rightIconView: UIImageView!
         if let rightIcon = rightIcon {
-            rightIconView = UIImageView(image: rightIcon.withRenderingMode(.alwaysTemplate))
-            
             if let rightIconColor = rightIconColor {
+                rightIconView = UIImageView(image: rightIcon.withRenderingMode(.alwaysTemplate))
                 rightIconView.tintColor = rightIconColor
+            } else {
+                rightIconView = UIImageView(image: rightIcon)
             }
         }
         

--- a/Sources/WUMessagesProtocol.swift
+++ b/Sources/WUMessagesProtocol.swift
@@ -11,7 +11,9 @@ public protocol WUMessagesProtocol {
         backgroundColor: UIColor?,
         onTap: OnTap?,
         leftIcon: UIImage?,
+        leftIconColor: UIColor?,
         rightIcon: UIImage?,
+        rightIconColor: UIColor?,
         timeout: DispatchTimeInterval
     )
     


### PR DESCRIPTION
Currently, for icons to display properly in notification banners, we need the assets to be exactly as they're intended to look like - correct colors and rendering mode -, which is not always the case.

By exposing a `color` parameter for each icon, we can conditionally force the asset to be rendered as a template and then apply whatever tint color, requiring less specific assets from the Design team and potentially saving time.